### PR TITLE
add functions to check and start sapstartsrv if not running

### DIFF
--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -22,7 +22,13 @@ jobs:
           - stable-2.11
           - stable-2.12
           - stable-2.13
-    runs-on: ubuntu-latest
+          - stable-2.14
+          - devel
+
+    runs-on: >-
+      ${{ contains(fromJson(
+          '["stable-2.9", "stable-2.10", "stable-2.11", "stable-2.12", "stable-2.13", "stable-2.14"]'
+      ), matrix.ansible) && 'ubuntu-20.04' || 'ubuntu-latest' }}
     steps:
 
       - name: Check out code
@@ -36,37 +42,23 @@ jobs:
         
 
   units:
-    runs-on: ubuntu-latest
+    runs-on: >-
+      ${{ contains(fromJson(
+          '["stable-2.9", "stable-2.10", "stable-2.11", "stable-2.12", "stable-2.13", "stable-2.14"]'
+      ), matrix.ansible) && 'ubuntu-20.04' || 'ubuntu-latest' }}
     name: Units (Ⓐ${{ matrix.ansible }}+py${{ matrix.python }})
     strategy:
       # As soon as the first unit test fails, cancel the others to free up the CI queue
       fail-fast: true
       matrix:
         ansible:
-          - stable-2.9 # Only if your collection supports Ansible 2.9
+          - stable-2.9
           - stable-2.10
           - stable-2.11
           - stable-2.12
           - stable-2.13
-        python:
-          - 2.6
-          - 2.7
-          - 3.5
-          - 3.6
-          - 3.7
-          - 3.8
-          - 3.9
-        exclude:
-          # Because ansible-test doesn't support python3.9 for Ansible 2.9
-          - ansible: stable-2.9
-            python: 3.9
-          - ansible: stable-2.13
-            python: 2.6
-        include:
-          # Test Devel on Python 3.10 only
-          - ansible: devel
-            python: '3.10'
-        
+          - stable-2.14
+          - devel
 
     steps:
       - name: Check out code
@@ -76,8 +68,6 @@ jobs:
         uses: ansible-community/ansible-test-gh-action@release/v1
         with:
           ansible-core-version: ${{ matrix.ansible }}
-          target-python-version: ${{ matrix.python }}
-          python-version: '3.10'
           testing-type: units
           test-deps: >-
             ansible.netcommon

--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -32,7 +32,7 @@ jobs:
     steps:
 
       - name: Check out code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Perform sanity testing with ansible-test
         uses: ansible-community/ansible-test-gh-action@release/v1
@@ -62,7 +62,7 @@ jobs:
 
     steps:
       - name: Check out code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Perform unit testing with ansible-test
         uses: ansible-community/ansible-test-gh-action@release/v1
@@ -105,7 +105,7 @@ jobs:
 
   #   steps:
   #     - name: Check out code
-  #       uses: actions/checkout@v2
+  #       uses: actions/checkout@v3
 
   #     - name: Perform integration testing with ansible-test
   #       uses: ansible-community/ansible-test-gh-action@release/v1

--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -23,6 +23,8 @@ jobs:
           - stable-2.12
           - stable-2.13
           - stable-2.14
+          - stable-2.15
+          - stable-2.16
           - devel
 
     runs-on: >-
@@ -32,7 +34,7 @@ jobs:
     steps:
 
       - name: Check out code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Perform sanity testing with ansible-test
         uses: ansible-community/ansible-test-gh-action@release/v1
@@ -58,20 +60,22 @@ jobs:
           - stable-2.12
           - stable-2.13
           - stable-2.14
+          - stable-2.15
+          - stable-2.16
           - devel
 
     steps:
       - name: Check out code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Perform unit testing with ansible-test
         uses: ansible-community/ansible-test-gh-action@release/v1
         with:
           ansible-core-version: ${{ matrix.ansible }}
           testing-type: units
-          test-deps: >-
-            ansible.netcommon
-            ansible.utils
+          # test-deps: >-
+          #   ansible.netcommon
+          #   ansible.utils
 
 # Please consult the Readme for information on why we disabled integration tests temporarily.
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,7 +5,7 @@ Community SAP Release Notes
 .. contents:: Topics
 
 
-v1.3.0
+v1.4.0
 ======
 
 Release Summary
@@ -14,6 +14,20 @@ Release Summary
 This is the 1.3.0 minor release of the ``community.sap_libs`` collection.
 This changelog contains all changes to the modules and plugins in this collection
 that have been made after the previous release.
+
+Bugfixes
+--------
+
+- fix a bug where some commands produces no output which cause to crash the module.
+- modules - fix a "variable used before assignment" that cannot be reached but causes sanity test failures.
+
+v1.3.0
+======
+
+Release Summary
+---------------
+
+This is the 1.3.0 minor release of the ``community.sap_libs`` collection. This changelog contains all changes to the modules and plugins in this collection that have been made after the previous release.
 
 Minor Changes
 -------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,26 @@ Community SAP Release Notes
 .. contents:: Topics
 
 
+v1.4.1
+======
+
+Release Summary
+---------------
+
+This is the 1.4.1 patch release of the ``community.sap_libs`` collection.
+This changelog contains all changes to the modules and plugins in this collection
+that have been made after the previous release.
+
+Bugfixes
+--------
+
+- fixes failures in sanity test for plugins/modules/sap_pyrfc.py
+- fixes failures in sanity test for tests/unit/compat/builtins.py
+- fixes failures in sanity test for tests/unit/plugins/modules/test_sap_system_facts.py
+- fixes failures in sanity test for tests/unit/plugins/modules/test_sap_system_facts.py
+- fixes pipeline warnings
+- sapcontrol_exec - This pr fixes problems on c(StartSystem), c(StopSystem), c(RestartSystem) which needs parameters they ca not provided by the parameters argument because of special format like c(waittimeout=1) without string quotes. This is caused by the suds module itself.
+
 v1.4.0
 ======
 

--- a/README.md
+++ b/README.md
@@ -71,6 +71,8 @@ Tested Ansible versions:
 - 2.12
 - 2.13
 - 2.14
+- 2.15
+- 2.16
 - devel
 
 Tested Python versions:
@@ -102,14 +104,14 @@ For some modules the below requirements are needed on the host that executes a m
 ## Included content
 
 - **Modules**:
-  - [sap_hdbsql](https://docs.ansible.com/ansible/latest/collections/community/sap_libs/sap_hdbsql.html)
-  - [sap_task_list_execute](https://docs.ansible.com/ansible/latest/collections/community/sap_libs/sap_task_list_execute.html)
-  - [sapcar_extract](https://docs.ansible.com/ansible/latest/collections/community/sap_libs/sapcar_extract.html)
-  - [sap_company](https://docs.ansible.com/ansible/latest/collections/community/sap_libs/sap_company.html)
-  - [sap_snote](https://docs.ansible.com/ansible/latest/collections/community/sap_libs/sap_snote.html)
-  - [sap_user](https://docs.ansible.com/ansible/latest/collections/community/sap_libs/sap_user.html)
-  - [sap_system_facts](https://docs.ansible.com/ansible/latest/collections/community/sap_libs/sap_system_facts.html)
-  - [sap_control_exec](https://docs.ansible.com/ansible/latest/collections/community/sap_libs/sap_control_exec.html)
+  - [sap_hdbsql](https://docs.ansible.com/ansible/latest/collections/community/sap_libs/sap_hdbsql_module.html)
+  - [sap_task_list_execute](https://docs.ansible.com/ansible/latest/collections/community/sap_libs/sap_task_list_execute_module.html)
+  - [sapcar_extract](https://docs.ansible.com/ansible/latest/collections/community/sap_libs/sapcar_extract_module.html)
+  - [sap_company](https://docs.ansible.com/ansible/latest/collections/community/sap_libs/sap_company_module.html)
+  - [sap_snote](https://docs.ansible.com/ansible/latest/collections/community/sap_libs/sap_snote_module.html)
+  - [sap_user](https://docs.ansible.com/ansible/latest/collections/community/sap_libs/sap_user_module.html)
+  - [sap_system_facts](https://docs.ansible.com/ansible/latest/collections/community/sap_libs/sap_system_facts_module.html)
+  - [sap_control_exec](https://docs.ansible.com/ansible/latest/collections/community/sap_libs/sap_control_exec_module.html)
 
 ## Using this collection
 

--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ Tested Ansible versions:
 - 2.11
 - 2.12
 - 2.13
+- 2.14
 - devel
 
 Tested Python versions:
@@ -80,6 +81,8 @@ Tested Python versions:
 - 3.7
 - 3.8
 - 3.9
+- 3.10
+- 3.11
 
 Due to SAP licensing and hardware requirements, integration tests are momentarily not feasible.
 The modules are tested manually against SAP systems until we found a solution or have some

--- a/changelogs/changelog.yaml
+++ b/changelogs/changelog.yaml
@@ -95,3 +95,22 @@ releases:
     - 1.4.0.yml
     - 22-use-before-assignment.yml
     release_date: '2022-12-05'
+  1.4.1:
+    changes:
+      bugfixes:
+      - fixes failures in sanity test for plugins/modules/sap_pyrfc.py
+      - fixes failures in sanity test for tests/unit/compat/builtins.py
+      - fixes failures in sanity test for tests/unit/plugins/modules/test_sap_system_facts.py
+      - fixes failures in sanity test for tests/unit/plugins/modules/test_sap_system_facts.py
+      - fixes pipeline warnings
+      - sapcontrol_exec - This pr fixes problems on c(StartSystem), c(StopSystem),
+        c(RestartSystem) which needs parameters they ca not provided by the parameters
+        argument because of special format like c(waittimeout=1) without string quotes.
+        This is caused by the suds module itself.
+      release_summary: This is the 1.4.1 patch release of the ``community.sap_libs``
+        collection. This changelog contains all changes to the modules and plugins
+        in this collection that have been made after the previous release. 
+    fragments:
+    - 28-fix-sapcontrol-issue.yml
+    - 29-fix-lint-issues.yml
+    release_date: '2023-03-09'

--- a/changelogs/changelog.yaml
+++ b/changelogs/changelog.yaml
@@ -64,7 +64,6 @@ releases:
     release_date: '2022-07-18'
   1.3.0:
     changes:
-      breaking_changes:
       minor_changes:
       - License requirements are updated.
       - The modules purposes are described clearer.
@@ -72,10 +71,27 @@ releases:
       - hana_query - module is moved to sap_hdbsql.
       - sapcontrol - module is moved to sap_control_exec to have a clearer separation
         to other roles and references.
-      release_summary: 'This is the 1.3.0 minor release of the ``community.sap_libs``
-        collection.
-        This changelog contains all changes to the modules and plugins in this collection
-        that have been made after the previous release.'
+      release_summary: This is the 1.3.0 minor release of the ``community.sap_libs``
+        collection. This changelog contains all changes to the modules and plugins
+        in this collection that have been made after the previous release.
     fragments:
     - 1.3.0.yml
     release_date: '2022-09-09'
+  1.4.0:
+    changes:
+      bugfixes:
+      - fix a bug where some commands produces no output which cause to crash the
+        module.
+      - modules - fix a "variable used before assignment" that cannot be reached but
+        causes sanity test failures.
+      release_summary: 'This is the 1.3.0 minor release of the ``community.sap_libs``
+        collection.
+
+        This changelog contains all changes to the modules and plugins in this collection
+
+        that have been made after the previous release.'
+    fragments:
+    - 0020-fix_sap_control_exec.yml
+    - 1.4.0.yml
+    - 22-use-before-assignment.yml
+    release_date: '2022-12-05'

--- a/changelogs/fragments/28-fix-sapcontrol-issue.yml
+++ b/changelogs/fragments/28-fix-sapcontrol-issue.yml
@@ -1,4 +1,0 @@
-bugfixes:
-  - sapcontrol_exec - This pr fixes problems on c(StartSystem), c(StopSystem), c(RestartSystem) which needs parameters
-    they ca not provided by the parameters argument because of special format like c(waittimeout=1) without string quotes. 
-    This is caused by the suds module itself.

--- a/changelogs/fragments/28-fix-sapcontrol-issue.yml
+++ b/changelogs/fragments/28-fix-sapcontrol-issue.yml
@@ -1,0 +1,4 @@
+bugfixes:
+  - sapcontrol_exec - This pr fixes problems on c(StartSystem), c(StopSystem), c(RestartSystem) which needs parameters
+    they ca not provided by the parameters argument because of special format like c(waittimeout=1) without string quotes. 
+    This is caused by the suds module itself.

--- a/changelogs/fragments/29-fix-lint-issues.yml
+++ b/changelogs/fragments/29-fix-lint-issues.yml
@@ -1,0 +1,6 @@
+bugfixes:
+  - fixes failures in sanity test for plugins/modules/sap_pyrfc.py
+  - fixes failures in sanity test for tests/unit/compat/builtins.py
+  - fixes failures in sanity test for tests/unit/plugins/modules/test_sap_system_facts.py
+  - fixes failures in sanity test for tests/unit/plugins/modules/test_sap_system_facts.py
+  - fixes pipeline warnings

--- a/changelogs/fragments/29-fix-lint-issues.yml
+++ b/changelogs/fragments/29-fix-lint-issues.yml
@@ -1,6 +1,0 @@
-bugfixes:
-  - fixes failures in sanity test for plugins/modules/sap_pyrfc.py
-  - fixes failures in sanity test for tests/unit/compat/builtins.py
-  - fixes failures in sanity test for tests/unit/plugins/modules/test_sap_system_facts.py
-  - fixes failures in sanity test for tests/unit/plugins/modules/test_sap_system_facts.py
-  - fixes pipeline warnings

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -2,7 +2,7 @@
 
 namespace: community
 name: sap_libs
-version: 1.3.0
+version: 1.4.0
 readme: README.md
 authors:
   - Rainer Leber (github.com/rainerleber)

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -2,7 +2,7 @@
 
 namespace: community
 name: sap_libs
-version: 1.4.0
+version: 1.4.1
 readme: README.md
 authors:
   - Rainer Leber (github.com/rainerleber)

--- a/plugins/module_utils/swpm2_parameters_inifile_generate.py
+++ b/plugins/module_utils/swpm2_parameters_inifile_generate.py
@@ -68,6 +68,9 @@ def control_xml_utf8(filepath, module):
     string = etree.tostring(root, xml_declaration=True, encoding="UTF-8",
                             pretty_print=True).decode('utf8').encode('iso-8859-1')
 
+#    string1 = etree.tostring(root, xml_declaration=True, encoding="UTF-8",
+#                            pretty_print=True).decode('utf8').encode('utf-8').strip()
+
     with open('control_utf8.xml', 'wb') as target:
         target.write(string)
 

--- a/plugins/modules/sap_company.py
+++ b/plugins/modules/sap_company.py
@@ -199,6 +199,7 @@ except ImportError:
     HAS_PYRFC_LIBRARY = False
     ANOTHER_LIBRARY_IMPORT_ERROR = traceback.format_exc()
 else:
+    ANOTHER_LIBRARY_IMPORT_ERROR = None
     HAS_PYRFC_LIBRARY = True
 
 

--- a/plugins/modules/sap_control_exec.py
+++ b/plugins/modules/sap_control_exec.py
@@ -267,6 +267,7 @@ except ImportError:
     HAS_SUDS_LIBRARY = False
     SUDS_LIBRARY_IMPORT_ERROR = traceback.format_exc()
 else:
+    SUDS_LIBRARY_IMPORT_ERROR = None
     HAS_SUDS_LIBRARY = True
 
 
@@ -384,7 +385,10 @@ def main():
         result['msg'] = 'Something went wrong connecting to the SAPCONTROL SOAP API.'
         module.fail_json(**result)
 
-    returned_data = recursive_dict(conn)
+    if conn is not None:
+        returned_data = recursive_dict(conn)
+    else:
+        returned_data = conn
 
     result['changed'] = True
     result['msg'] = "Succesful execution of: " + function

--- a/plugins/modules/sap_control_exec.py
+++ b/plugins/modules/sap_control_exec.py
@@ -324,6 +324,10 @@ def connection(hostname, port, username, password, function, parameter):
     _function = getattr(client.service, function)
     if parameter is not None:
         result = _function(parameter)
+    elif function == "StartSystem":
+        result = _function(waittimeout=0)
+    elif function == "StopSystem" or function == "RestartSystem":
+        result = _function(waittimeout=0, softtimeout=0)
     else:
         result = _function()
 

--- a/plugins/modules/sap_pyrfc.py
+++ b/plugins/modules/sap_pyrfc.py
@@ -113,7 +113,7 @@ from ansible.module_utils.basic import AnsibleModule, missing_required_lib
 from ..module_utils.pyrfc_handler import get_connection
 
 try:
-    from pyrfc import ABAPApplicationError, ABAPRuntimeError, CommunicationError, Connection, LogonError
+    from pyrfc import ABAPApplicationError, ABAPRuntimeError, CommunicationError, LogonError
 except ImportError:
     HAS_PYRFC_LIBRARY = False
     PYRFC_LIBRARY_IMPORT_ERROR = traceback.format_exc()

--- a/plugins/modules/sap_pyrfc.py
+++ b/plugins/modules/sap_pyrfc.py
@@ -118,6 +118,7 @@ except ImportError:
     HAS_PYRFC_LIBRARY = False
     PYRFC_LIBRARY_IMPORT_ERROR = traceback.format_exc()
 else:
+    PYRFC_LIBRARY_IMPORT_ERROR = None
     HAS_PYRFC_LIBRARY = True
 
 
@@ -162,6 +163,7 @@ def main():
     try:
         conn = get_connection(module, conn_params)
         result = conn.call(function, **func_params)
+        error_msg = None
     except CommunicationError as err:
         msg = "Could not connect to server"
         error_msg = err.message

--- a/plugins/modules/sap_snote.py
+++ b/plugins/modules/sap_snote.py
@@ -147,6 +147,7 @@ except ImportError:
     HAS_PYRFC_LIBRARY = False
     ANOTHER_LIBRARY_IMPORT_ERROR = traceback.format_exc()
 else:
+    ANOTHER_LIBRARY_IMPORT_ERROR = None
     HAS_PYRFC_LIBRARY = True
 
 

--- a/plugins/modules/sap_task_list_execute.py
+++ b/plugins/modules/sap_task_list_execute.py
@@ -193,6 +193,7 @@ except ImportError:
     HAS_PYRFC_LIBRARY = False
     PYRFC_LIBRARY_IMPORT_ERROR = traceback.format_exc()
 else:
+    PYRFC_LIBRARY_IMPORT_ERROR = None
     HAS_PYRFC_LIBRARY = True
 try:
     import xmltodict
@@ -200,6 +201,7 @@ except ImportError:
     HAS_XMLTODICT_LIBRARY = False
     XMLTODICT_LIBRARY_IMPORT_ERROR = traceback.format_exc()
 else:
+    XMLTODICT_LIBRARY_IMPORT_ERROR = None
     HAS_XMLTODICT_LIBRARY = True
 
 

--- a/plugins/modules/sap_user.py
+++ b/plugins/modules/sap_user.py
@@ -246,6 +246,7 @@ except ImportError:
     HAS_PYRFC_LIBRARY = False
     PYRFC_LIBRARY_IMPORT_ERROR = traceback.format_exc()
 else:
+    PYRFC_LIBRARY_IMPORT_ERROR = None
     HAS_PYRFC_LIBRARY = True
 
 

--- a/tests/sanity/ignore-2.14.txt
+++ b/tests/sanity/ignore-2.14.txt
@@ -1,0 +1,9 @@
+plugins/modules/sap_pyrfc.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0
+plugins/modules/sap_company.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0
+plugins/modules/sap_control_exec.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0
+plugins/modules/sap_hdbsql.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0
+plugins/modules/sap_snote.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0
+plugins/modules/sap_system_facts.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0
+plugins/modules/sap_task_list_execute.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0
+plugins/modules/sap_user.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0
+plugins/modules/sapcar_extract.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0

--- a/tests/sanity/ignore-2.15.txt
+++ b/tests/sanity/ignore-2.15.txt
@@ -1,0 +1,9 @@
+plugins/modules/sap_pyrfc.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0
+plugins/modules/sap_company.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0
+plugins/modules/sap_control_exec.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0
+plugins/modules/sap_hdbsql.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0
+plugins/modules/sap_snote.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0
+plugins/modules/sap_system_facts.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0
+plugins/modules/sap_task_list_execute.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0
+plugins/modules/sap_user.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0
+plugins/modules/sapcar_extract.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0

--- a/tests/sanity/ignore-2.16.txt
+++ b/tests/sanity/ignore-2.16.txt
@@ -1,0 +1,9 @@
+plugins/modules/sap_pyrfc.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0
+plugins/modules/sap_company.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0
+plugins/modules/sap_control_exec.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0
+plugins/modules/sap_hdbsql.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0
+plugins/modules/sap_snote.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0
+plugins/modules/sap_system_facts.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0
+plugins/modules/sap_task_list_execute.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0
+plugins/modules/sap_user.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0
+plugins/modules/sapcar_extract.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0

--- a/tests/sanity/ignore-2.17.txt
+++ b/tests/sanity/ignore-2.17.txt
@@ -1,0 +1,9 @@
+plugins/modules/sap_pyrfc.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0
+plugins/modules/sap_company.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0
+plugins/modules/sap_control_exec.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0
+plugins/modules/sap_hdbsql.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0
+plugins/modules/sap_snote.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0
+plugins/modules/sap_system_facts.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0
+plugins/modules/sap_task_list_execute.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0
+plugins/modules/sap_user.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0
+plugins/modules/sapcar_extract.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0

--- a/tests/unit/compat/builtins.py
+++ b/tests/unit/compat/builtins.py
@@ -22,12 +22,3 @@ __metaclass__ = type
 #
 # Compat for python2.7
 #
-
-# One unittest needs to import builtins via __import__() so we need to have
-# the string that represents it
-try:
-    import __builtin__
-except ImportError:
-    BUILTINS = 'builtins'
-else:
-    BUILTINS = '__builtin__'

--- a/tests/unit/mock/loader.py
+++ b/tests/unit/mock/loader.py
@@ -1,6 +1,7 @@
-# (c) 2012-2014, Michael DeHaan <michael.dehaan@gmail.com>
+# Copyright (c) 2012-2014, Michael DeHaan <michael.dehaan@gmail.com>
 #
-# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
 
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
@@ -16,7 +17,7 @@ class DictDataLoader(DataLoader):
 
     def __init__(self, file_mapping=None):
         file_mapping = {} if file_mapping is None else file_mapping
-        assert type(file_mapping) == dict
+        assert isinstance(file_mapping, dict)
 
         super(DictDataLoader, self).__init__()
 

--- a/tests/unit/plugins/modules/test_sap_system_facts.py
+++ b/tests/unit/plugins/modules/test_sap_system_facts.py
@@ -5,12 +5,11 @@
 
 from __future__ import absolute_import, division, print_function
 
-import mock
 __metaclass__ = type
 
 from ansible_collections.community.sap_libs.plugins.modules import sap_system_facts
 from ansible_collections.community.sap_libs.tests.unit.plugins.modules.utils import AnsibleExitJson, ModuleTestCase
-from ansible_collections.community.sap_libs.tests.unit.compat.mock import patch, MagicMock
+from ansible_collections.community.sap_libs.tests.unit.compat.mock import patch
 from ansible.module_utils import basic
 
 


### PR DESCRIPTION
In the existing version of sap_system_facts.py assumes the sapstartsrv service is running in order to effectively pull details about the type of SAP system. My proposal is to add two additional functions. 

1. get_sap_srv_status(ins_sid, ins_nr) will check to see if sapstartsrv is running.
2. start_sap_srv(ins_sid, ins_nr) will start the services if it is not running. 
