### PR TITLE
Pipeline fixes and drop test support for ansible <= 2.12

### DIFF
--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -62,6 +62,7 @@ jobs:
           - stable-2.14
           - stable-2.15
           - stable-2.16
+          - stable-2.17
           - devel
 
     steps:

--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -25,6 +25,7 @@ jobs:
           - stable-2.14
           - stable-2.15
           - stable-2.16
+          - stable-2.17
           - devel
 
     runs-on: >-

--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -17,10 +17,6 @@ jobs:
     strategy:
       matrix:
         ansible:
-          - stable-2.9
-          - stable-2.10
-          - stable-2.11
-          - stable-2.12
           - stable-2.13
           - stable-2.14
           - stable-2.15
@@ -30,7 +26,7 @@ jobs:
 
     runs-on: >-
       ${{ contains(fromJson(
-          '["stable-2.9", "stable-2.10", "stable-2.11", "stable-2.12", "stable-2.13", "stable-2.14"]'
+          '["stable-2.13", "stable-2.14"]'
       ), matrix.ansible) && 'ubuntu-20.04' || 'ubuntu-latest' }}
     steps:
 
@@ -47,7 +43,7 @@ jobs:
   units:
     runs-on: >-
       ${{ contains(fromJson(
-          '["stable-2.9", "stable-2.10", "stable-2.11", "stable-2.12", "stable-2.13", "stable-2.14"]'
+          '["stable-2.13", "stable-2.14"]'
       ), matrix.ansible) && 'ubuntu-20.04' || 'ubuntu-latest' }}
     name: Units (Ⓐ${{ matrix.ansible }}+py${{ matrix.python }})
     strategy:
@@ -55,10 +51,6 @@ jobs:
       fail-fast: true
       matrix:
         ansible:
-          - stable-2.9
-          - stable-2.10
-          - stable-2.11
-          - stable-2.12
           - stable-2.13
           - stable-2.14
           - stable-2.15

--- a/README.md
+++ b/README.md
@@ -65,10 +65,6 @@ Every voice is important. If you have something on your mind, create an issue or
 ## Tested with Ansible and the following Python versions
 
 Tested Ansible versions:
-- 2.9
-- 2.10
-- 2.11
-- 2.12
 - 2.13
 - 2.14
 - 2.15
@@ -76,9 +72,6 @@ Tested Ansible versions:
 - devel
 
 Tested Python versions:
-- 2.6
-- 2.7
-- 3.5
 - 3.6
 - 3.7
 - 3.8
@@ -89,6 +82,9 @@ Tested Python versions:
 Due to SAP licensing and hardware requirements, integration tests are momentarily not feasible.
 The modules are tested manually against SAP systems until we found a solution or have some
 modules where we are able to execute integration test we decided to disable these tests.
+
+The test support for Ansible versions 2.9 - 2.12 is disabled due to eol of these versions.
+The modules may work with these versions but are not tested.
 
 ## External requirements
 

--- a/changelogs/fragments/0043-Ansible_eol_support_drop.yaml
+++ b/changelogs/fragments/0043-Ansible_eol_support_drop.yaml
@@ -1,0 +1,5 @@
+minor_changes:
+  - Drop support for ansible <= 2.12
+  - Add test for ansible 2.18 aka devel
+bugfixes:
+  - Fix pipelines

--- a/tests/sanity/ignore-2.17.txt
+++ b/tests/sanity/ignore-2.17.txt
@@ -7,3 +7,4 @@ plugins/modules/sap_system_facts.py validate-modules:missing-gplv3-license # Lic
 plugins/modules/sap_task_list_execute.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0
 plugins/modules/sap_user.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0
 plugins/modules/sapcar_extract.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0
+tests/unit/compat/mock.py pylint:use-yield-from  # suggested construct does not work with Python 2

--- a/tests/sanity/ignore-2.18.txt
+++ b/tests/sanity/ignore-2.18.txt
@@ -1,0 +1,9 @@
+plugins/modules/sap_pyrfc.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0
+plugins/modules/sap_company.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0
+plugins/modules/sap_control_exec.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0
+plugins/modules/sap_hdbsql.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0
+plugins/modules/sap_snote.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0
+plugins/modules/sap_system_facts.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0
+plugins/modules/sap_task_list_execute.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0
+plugins/modules/sap_user.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0
+plugins/modules/sapcar_extract.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0

--- a/tests/sanity/ignore-2.18.txt
+++ b/tests/sanity/ignore-2.18.txt
@@ -7,3 +7,4 @@ plugins/modules/sap_system_facts.py validate-modules:missing-gplv3-license # Lic
 plugins/modules/sap_task_list_execute.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0
 plugins/modules/sap_user.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0
 plugins/modules/sapcar_extract.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0
+tests/unit/compat/mock.py pylint:use-yield-from  # suggested construct does not work with Python 2

--- a/tests/unit/compat/mock.py
+++ b/tests/unit/compat/mock.py
@@ -1,19 +1,6 @@
-# (c) 2014, Toshio Kuratomi <tkuratomi@ansible.com>
-#
-# This file is part of Ansible
-#
-# Ansible is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# Ansible is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+# Copyright (c) 2014, Toshio Kuratomi <tkuratomi@ansible.com>
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
 
 # Make coding more python3-ish
 from __future__ import (absolute_import, division, print_function)
@@ -33,12 +20,12 @@ try:
     # Allow wildcard import because we really do want to import all of mock's
     # symbols into this compat shim
     # pylint: disable=wildcard-import,unused-wildcard-import
-    from unittest.mock import *
+    from unittest.mock import *  # noqa: F401, pylint: disable=unused-import
 except ImportError:
     # Python 2
     # pylint: disable=wildcard-import,unused-wildcard-import
     try:
-        from mock import *
+        from mock import *  # noqa: F401, pylint: disable=unused-import
     except ImportError:
         print('You need the mock library installed on python2.x to run tests')
 

--- a/tests/unit/compat/mock.py
+++ b/tests/unit/compat/mock.py
@@ -52,7 +52,7 @@ if sys.version_info >= (3,) and sys.version_info < (3, 4, 4):
             data_as_list[-1] = data_as_list[-1][:-1]
 
         for line in data_as_list:
-            yield line  # noqa: use-yield-from
+            yield line  # noqa: pylint: disable=use-yield-from
 
     def mock_open(mock=None, read_data=''):
         """
@@ -81,7 +81,7 @@ if sys.version_info >= (3,) and sys.version_info < (3, 4, 4):
                 while True:
                     yield handle.readline.return_value
             for line in _data:
-                yield line  # noqa: use-yield-from
+                yield line  # noqa: pylint: disable=use-yield-from
 
         global file_spec
         if file_spec is None:

--- a/tests/unit/compat/mock.py
+++ b/tests/unit/compat/mock.py
@@ -1,6 +1,19 @@
-# Copyright (c) 2014, Toshio Kuratomi <tkuratomi@ansible.com>
-# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
-# SPDX-License-Identifier: GPL-3.0-or-later
+# (c) 2014, Toshio Kuratomi <tkuratomi@ansible.com>
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 
 # Make coding more python3-ish
 from __future__ import (absolute_import, division, print_function)
@@ -20,12 +33,12 @@ try:
     # Allow wildcard import because we really do want to import all of mock's
     # symbols into this compat shim
     # pylint: disable=wildcard-import,unused-wildcard-import
-    from unittest.mock import *  # noqa: F401, pylint: disable=unused-import
+    from unittest.mock import *
 except ImportError:
     # Python 2
     # pylint: disable=wildcard-import,unused-wildcard-import
     try:
-        from mock import *  # noqa: F401, pylint: disable=unused-import
+        from unittest.mock import *
     except ImportError:
         print('You need the mock library installed on python2.x to run tests')
 
@@ -50,7 +63,10 @@ if sys.version_info >= (3,) and sys.version_info < (3, 4, 4):
             # emulated doesn't have a newline to end the last line  remove the
             # newline that our naive format() added
             data_as_list[-1] = data_as_list[-1][:-1]
-        yield from (line for line in data_as_list)
+
+        
+        for line in data_as_list:
+            yield line # noga: use-yield-from
 
     def mock_open(mock=None, read_data=''):
         """
@@ -78,7 +94,8 @@ if sys.version_info >= (3,) and sys.version_info < (3, 4, 4):
             if handle.readline.return_value is not None:
                 while True:
                     yield handle.readline.return_value
-            yield from (line for line in _data)
+            for line in _data:
+                yield line # noga: use-yield-from
 
         global file_spec
         if file_spec is None:

--- a/tests/unit/compat/mock.py
+++ b/tests/unit/compat/mock.py
@@ -50,9 +50,7 @@ if sys.version_info >= (3,) and sys.version_info < (3, 4, 4):
             # emulated doesn't have a newline to end the last line  remove the
             # newline that our naive format() added
             data_as_list[-1] = data_as_list[-1][:-1]
-
-        for line in data_as_list:
-            yield line
+        yield from (line for line in data_as_list)
 
     def mock_open(mock=None, read_data=''):
         """
@@ -80,8 +78,7 @@ if sys.version_info >= (3,) and sys.version_info < (3, 4, 4):
             if handle.readline.return_value is not None:
                 while True:
                     yield handle.readline.return_value
-            for line in _data:
-                yield line
+            yield from (line for line in _data)
 
         global file_spec
         if file_spec is None:

--- a/tests/unit/compat/mock.py
+++ b/tests/unit/compat/mock.py
@@ -52,7 +52,7 @@ if sys.version_info >= (3,) and sys.version_info < (3, 4, 4):
             data_as_list[-1] = data_as_list[-1][:-1]
 
         for line in data_as_list:
-            yield line  # noqa: pylint: disable=use-yield-from
+            yield line
 
     def mock_open(mock=None, read_data=''):
         """
@@ -81,7 +81,7 @@ if sys.version_info >= (3,) and sys.version_info < (3, 4, 4):
                 while True:
                     yield handle.readline.return_value
             for line in _data:
-                yield line  # noqa: pylint: disable=use-yield-from
+                yield line
 
         global file_spec
         if file_spec is None:

--- a/tests/unit/compat/mock.py
+++ b/tests/unit/compat/mock.py
@@ -1,19 +1,6 @@
-# (c) 2014, Toshio Kuratomi <tkuratomi@ansible.com>
-#
-# This file is part of Ansible
-#
-# Ansible is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# Ansible is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+# Copyright (c) 2014, Toshio Kuratomi <tkuratomi@ansible.com>
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
 
 # Make coding more python3-ish
 from __future__ import (absolute_import, division, print_function)
@@ -33,12 +20,12 @@ try:
     # Allow wildcard import because we really do want to import all of mock's
     # symbols into this compat shim
     # pylint: disable=wildcard-import,unused-wildcard-import
-    from unittest.mock import *
+    from unittest.mock import *  # noqa: F401, pylint: disable=unused-import
 except ImportError:
     # Python 2
     # pylint: disable=wildcard-import,unused-wildcard-import
     try:
-        from unittest.mock import *
+        from mock import *  # noqa: F401, pylint: disable=unused-import
     except ImportError:
         print('You need the mock library installed on python2.x to run tests')
 
@@ -64,9 +51,8 @@ if sys.version_info >= (3,) and sys.version_info < (3, 4, 4):
             # newline that our naive format() added
             data_as_list[-1] = data_as_list[-1][:-1]
 
-        
         for line in data_as_list:
-            yield line # noga: use-yield-from
+            yield line  # noqa: use-yield-from
 
     def mock_open(mock=None, read_data=''):
         """
@@ -95,7 +81,7 @@ if sys.version_info >= (3,) and sys.version_info < (3, 4, 4):
                 while True:
                     yield handle.readline.return_value
             for line in _data:
-                yield line # noga: use-yield-from
+                yield line  # noqa: use-yield-from
 
         global file_spec
         if file_spec is None:


### PR DESCRIPTION
This pull request refactors the mock.py. It also updates the license header and import statements, adds pylint disable comments, and removes some pylint disable comments. Additionally, it drops test support for Ansible versions 2.9 - 2.12.