### PR TITLE
add -ssltrustcert and -sslcreatecert for better client encryption handling

### DIFF
--- a/plugins/modules/sap_hdbsql.py
+++ b/plugins/modules/sap_hdbsql.py
@@ -209,7 +209,7 @@ def main():
         module.fail_json(msg='Failed to find hdbsql at the expected path "{0}".Please check SID and instance number: "{1}"'.format(bin_path, to_native(e)))
 
     if encrypted is True:
-        command.extend(['-attemptencrypt'])
+        command.extend(['-e' , '-ssltrustcert', '-sslcreatecert'])
     if autocommit is False:
         command.extend(['-z'])
     if host is not None:


### PR DESCRIPTION
Add specific client encryption parameters that allows constant access to the database with enforced encryption, without requiring individual client certificates