### PR TITLE
Update CI

### DIFF
--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -22,6 +22,8 @@ jobs:
           - stable-2.15
           - stable-2.16
           - stable-2.17
+          - stable-2.18
+          - stable-2.19
           - devel
 
     runs-on: >-
@@ -56,6 +58,8 @@ jobs:
           - stable-2.15
           - stable-2.16
           - stable-2.17
+          - stable-2.18
+          - stable-2.19
           - devel
 
     steps:


### PR DESCRIPTION
Currently, the collection isn't tested with ansible-core 2.18 and 2.19. But since 2.18 is the base for Ansible 11 and 2.19 for Ansible 12, which are both maintained ATM, I think you _have_ to [run those tests](https://docs.ansible.com/ansible/latest/community/collection_contributors/collection_requirements.html#ci-testing).

At least, if you want us to keep this collection in the Ansible Community Package.