### PR TITLE
When iterating sub-dirs in /sapmnt ignore entries owned by root. 

### DIFF
--- a/plugins/modules/sap_system_facts.py
+++ b/plugins/modules/sap_system_facts.py
@@ -98,7 +98,8 @@ def get_all_nw_sid():
     if os.path.isdir("/sapmnt"):
         # /sapmnt directory exists
         for sid in os.listdir('/sapmnt'):
-            if os.path.isdir("/usr/sap/" + sid):
+            # Iterate over directories and filter out those owned by root (e.g. lost+found).
+            if os.path.isdir("/usr/sap/" + sid) and os.stat("/usr/sap/" + sid).st_uid != 0:
                 nw_sid = nw_sid + [sid]
             else:
                 # Check to see if /sapmnt/SID/sap_bobj exists


### PR DESCRIPTION
E.g. a lost+found directory might other otherwise trigger permission error. Happened on one of our KfW servers with ext4 filesystems mounted on /sapmnt and /usr/sap. 

Directories /sapmnt/SID and /usr/sap/SID are supposed to be owned by sidadm anyway. So it is safe to ignore those owned by root.

Encountered error message:
[ERROR]: Task failed: Module failed: [Errno 13] Permission denied: '/usr/sap/lost+found'

Grüße vom Gendarmenmarkt.