### PR TITLE
sapcar_extract: Add overwrite mode and improve exist validation

### DIFF
--- a/plugins/modules/sapcar_extract.py
+++ b/plugins/modules/sapcar_extract.py
@@ -102,6 +102,34 @@ EXAMPLES = r"""
     signature: true
 """
 
+RETURN = r'''
+msg:
+    description: Status message about the extraction operation.
+    type: str
+    returned: always
+    sample: "Files extracted to /tmp/test2 (overwrite mode enabled)"
+stdout:
+    description: Standard output from the SAPCAR command.
+    type: str
+    returned: always
+    sample: "SAPCAR: processing archive /tmp/hana.sar (version 2.01)\\nfile1\\nfile2"
+stderr:
+    description: Standard error from the SAPCAR command.
+    type: str
+    returned: always
+    sample: ""
+command:
+    description: The full SAPCAR command that was executed.
+    type: str
+    returned: always
+    sample: "/tmp/sapcar -xvf /tmp/hana.sar -R /tmp/test2"
+changed:
+    description: Whether the module made changes.
+    type: bool
+    returned: always
+    sample: true
+'''
+
 import os
 from tempfile import NamedTemporaryFile
 from ansible.module_utils.basic import AnsibleModule

--- a/plugins/modules/sapcar_extract.py
+++ b/plugins/modules/sapcar_extract.py
@@ -231,15 +231,19 @@ def main():
         if not check_mode:
             (rc, out, err) = module.run_command(command, check_rc=True)
         changed = True
+        msg = "Files extracted to {0}".format(dest)
+        if params['overwrite']:
+            msg += " (overwrite mode enabled)"
 
     else:
         changed = False
-        out = "Expected file names were found in {0} folder. No extraction needed.".format(dest)
+        msg = "Expected file names were found in {0}. No extraction needed.".format(dest)
+        out = ""
 
     if params['remove']:
         os.remove(params['path'])
 
-    module.exit_json(changed=changed, message=rc, stdout=out,
+    module.exit_json(changed=changed, msg=msg, stdout=out,
                      stderr=err, command=' '.join(command))
 
 

--- a/plugins/modules/sapcar_extract.py
+++ b/plugins/modules/sapcar_extract.py
@@ -56,6 +56,13 @@ options:
       - If C(true), the SAR/CAR file will be removed. B(This should be used with caution!)
     default: false
     type: bool
+  overwrite:
+    description:
+      - If C(true), existing files will be overwritten during extraction. B(This should be used with caution!)
+      - If C(false), the module checks if the expected file names are already present in the destination folder and only extracts if they are not found.
+      - It does not remove files, but overwrites them if they are already present in the destination folder.
+    default: false
+    type: bool
 author:
     - Rainer Leber (@RainerLeber)
 notes:
@@ -139,24 +146,29 @@ def download_SAPCAR(binary_path, module):
 
 
 def check_if_present(command, path, dest, signature, manifest, module):
-    # manipulating output from SAR file for compare with already extracted files
+    # Get list of files from sar file without extraction
     iter_command = [command, '-tvf', path]
     sar_out = module.run_command(iter_command)[1]
     sar_raw = sar_out.split("\n")[1:]
+
     if dest[-1] != "/":
         dest = dest + "/"
     sar_files = [dest + x.split(" ")[-1] for x in sar_raw if x]
+
     # remove any SIGNATURE.SMF from list because it will not unpacked if signature is false
     if not signature:
         sar_files = [item for item in sar_files if not item.endswith('.SMF')]
+
     # if signature is renamed manipulate files in list of sar file for compare.
     if manifest != "SIGNATURE.SMF":
         sar_files = [item for item in sar_files if not item.endswith('.SMF')]
         sar_files = sar_files + [manifest]
+
     # get extracted files if present
     files_extracted = get_list_of_files(dest)
     # compare extracted files with files in sar file
     present = all(elem in files_extracted for elem in sar_files)
+
     return present
 
 
@@ -170,6 +182,7 @@ def main():
             security_library=dict(type='path'),
             manifest=dict(type='str', default="SIGNATURE.SMF"),
             remove=dict(type='bool', default=False),
+            overwrite=dict(type='bool', default=False)
         ),
         supports_check_mode=True,
     )
@@ -177,17 +190,19 @@ def main():
     params = module.params
     check_mode = module.check_mode
 
-    path = params['path']
-    dest = params['dest']
-    signature = params['signature']
-    security_library = params['security_library']
-    manifest = params['manifest']
-    remove = params['remove']
-
     bin_path = download_SAPCAR(params['binary_path'], module)
 
+    # Check if path is present and readable
+    if os.path.isfile(params['path']):
+        if not os.access(params['path'], os.R_OK):
+            module.fail_json(msg="Permission denied: File defined in the 'path' parameter is not readable: {0}".format(params['path']))
+    else:
+        module.fail_json(msg='File missing: File defined in the "path" parameter does not exist: {0}'.format(params['path']))
+
+    # Check if destination exists and it is directory, if not create it.
+    dest = params['dest']
     if dest is None:
-        dest_head_tail = os.path.split(path)
+        dest_head_tail = os.path.split(params['path'])
         dest = dest_head_tail[0] + '/'
     else:
         if not os.path.exists(dest):
@@ -202,23 +217,27 @@ def main():
             module.fail_json(msg='Failed to find SAPCAR at the expected path or URL "{0}". Please check whether it is available: {1}'
                              .format(bin_path, to_native(e)))
 
-    present = check_if_present(command[0], path, dest, signature, manifest, module)
+    present = check_if_present(command[0], params['path'], dest, params['signature'], params['manifest'], module)
 
-    if not present:
-        command.extend(['-xvf', path, '-R', dest])
-        if security_library:
-            command.extend(['-L', security_library])
-        if signature:
-            command.extend(['-manifest', manifest])
+    if not present or params['overwrite']:
+        command.extend(['-xvf', params['path'], '-R', dest])
+
+        if params['security_library']:
+            command.extend(['-L', params['security_library']])
+
+        if params['signature']:
+            command.extend(['-manifest', params['manifest']])
+
         if not check_mode:
             (rc, out, err) = module.run_command(command, check_rc=True)
         changed = True
+
     else:
         changed = False
-        out = "already unpacked"
+        out = "Expected file names were found in {0} folder. No extraction needed.".format(dest)
 
-    if remove:
-        os.remove(path)
+    if params['remove']:
+        os.remove(params['path'])
 
     module.exit_json(changed=changed, message=rc, stdout=out,
                      stderr=err, command=' '.join(command))

--- a/tests/unit/plugins/modules/test_sapcar_extract.py
+++ b/tests/unit/plugins/modules/test_sapcar_extract.py
@@ -45,10 +45,27 @@ class Testsapcar_extract(ModuleTestCase):
             'dest': "/tmp/test2",
             'binary_path': "/tmp/sapcar"
         }
-        with patch.object(basic.AnsibleModule, 'run_command') as run_command:
-            run_command.return_value = 0, '', ''  # successful execution, no output
+        with patch('os.path.isfile', return_value=True), \
+             patch('os.access', return_value=True), \
+             patch('os.path.exists', return_value=True), \
+             patch('os.listdir', return_value=[]), \
+             patch.object(basic.AnsibleModule, 'run_command') as run_command:
+            run_command.return_value = 0, 'file1\nfile2', ''
             with self.assertRaises(AnsibleExitJson) as result:
                 with set_module_args(args):
                     sapcar_extract.main()
-                self.assertTrue(result.exception.args[0]['changed'])
-        self.assertEqual(run_command.call_count, 1)
+            self.assertTrue(result.exception.args[0]['changed'])
+        self.assertGreaterEqual(run_command.call_count, 1)
+
+    def test_file_missing(self):
+        """Failure must occur when SAR file does not exist."""
+        args = {
+            'path': "/tmp/nonexistent.SAR",
+            'dest': "/tmp/test2",
+            'binary_path': "/tmp/sapcar"
+        }
+        with patch('os.path.isfile', return_value=False):
+            with self.assertRaises(AnsibleFailJson) as result:
+                with set_module_args(args):
+                    sapcar_extract.main()
+            self.assertIn('File missing', result.exception.args[0]['msg'])


### PR DESCRIPTION
## Changes
- Add new optional parameter `overwrite` which allows extraction regardless if files are present. We cannot validate that extracted files are what is in archive, only file names. Overwrite mode allows users to trigger overwrite like mentioned in https://github.com/sap-linuxlab/community.sap_libs/issues/71 by @crysaki @nbttmbrg 

- Add `path` validation and clearer messages, instead of incorrect message that files are already present. Mentioned in https://github.com/sap-linuxlab/community.sap_libs/issues/72 by @crysaki
  - Additional validation for permissions is added.

- Small refactoring for clarity and readability, not code change.

## Tests
Tested on SLES_SAP 16.0 with BW4HANA system.

`path` points to wrong archive, no longer success message:
```bash
msg: 'File missing: File defined in the "path" parameter does not exist: /software/SAPEXEDB_51-70007806.SARx'
```

`dest` contains expected file names, overwrite mode is disabled (default):
```bash
stdout: Expected file names were found in /tmp/sapcar_extract folder. No extraction needed.
```

`dest` contains expected file names, overwrite mode is enabled:
```bash
        stdout: |-
            SAPCAR: processing archive /software/SAPEXEDB_51-70007806.SAR (version 2.01)
            x db4cncl
            x dbdb2slib.so
            x dbdb4slib.so
            x dbdb6slib.so
```