### PR TITLE
sap_control_exec, sap_hostctrl_exec: QoL and Error handling

### DIFF
--- a/plugins/module_utils/sapstartsrv_client.py
+++ b/plugins/module_utils/sapstartsrv_client.py
@@ -63,6 +63,21 @@ except ImportError:
         def u2handlers(self):
             return []
 
+# Constant that defines accepted function prefixes, that are not doing changes.
+READ_ONLY_FUNCTION_PREFIXES = (
+    "get",
+    "list",
+    "enqget",
+    "abapget",
+    "icmget",
+    "cmget",
+    "webdispget",
+)
+
+# Constants that define if force mode is required for certain functions.
+FORCE_REQUIRED_PREFIXES = ("stop", "restart")
+FORCE_REQUIRED_EXACT = ("shutdown", "instancestop")
+
 
 class LocalSocketHttpConnection(HTTPConnection):
     """HTTP connection class that uses Unix domain sockets."""
@@ -85,6 +100,22 @@ class LocalSocketHandler(HTTPHandler):
 
     def http_open(self, req):
         return self.do_open(LocalSocketHttpConnection, req, socketpath=self._socketpath)
+
+
+def is_read_only_function(function_name):
+    """Return True for read-only functions (e.g. Get*, List*)."""
+    if not function_name:
+        return False
+    fname = function_name.strip().lower()
+    return any(fname.startswith(prefix) for prefix in READ_ONLY_FUNCTION_PREFIXES)
+
+
+def requires_force(function_name):
+    """Return True when function should require force=True."""
+    if not function_name:
+        return False
+    fname = function_name.strip().lower()
+    return fname in FORCE_REQUIRED_EXACT or fname.startswith(FORCE_REQUIRED_PREFIXES)
 
 
 def recursive_dict(suds_object):
@@ -110,46 +141,53 @@ def recursive_dict(suds_object):
     return out
 
 
-def connection(service_name, hostname, port, username, password, sysnr=None, use_local=False):
+def connection(service_name, hostname, port, username, password, sysnr=None, is_socket=False):
     """
     Return a SOAP client for the given service (sapcontrol or saphostctrl).
     """
-    if use_local:
+    # Prepare connection details before attempting to connect.
+    if is_socket:
         # Use Unix domain socket for local connection
         if sysnr is not None:
-            # For sapcontrol, the socket name includes the system number
+            # sapcontrol: The socket name includes the system number
             unix_socket = "/tmp/.sapstream5{0}13".format(str(sysnr).zfill(2))
         else:
-            # For saphostctrl, the socket name is fixed
+            # saphostctrl: The socket name is fixed
             unix_socket = "/tmp/.sapstream1128"
 
-        # Check if socket exists
-        if not os.path.exists(unix_socket):
-            raise Exception("SAP control Unix socket not found: {0}".format(unix_socket))
+        connection_url = "http://localhost/{0}?wsdl".format(service_name)
 
-        url = "http://localhost/{0}?wsdl".format(service_name)
-
-        try:
-            localsocket = LocalSocketHttpAuthenticated(unix_socket)
-            client = Client(url, transport=localsocket)
-        except Exception as e:
-            raise Exception("Failed to connect via Unix socket: {0}".format(str(e)))
     else:
         # Use HTTP connection (original behavior)
-        url = 'http://{0}:{1}/{2}?wsdl'.format(hostname, port, service_name)
-        client = Client(url, username=username, password=password)
+        connection_url = 'http://{0}:{1}/{2}?wsdl'.format(hostname, port, service_name)
 
-    return client
+    # Attempt to connect using the appropriate method
+    try:
+        if is_socket:
+            if not os.path.exists(unix_socket):
+                raise Exception("SAP control Unix socket not found: {0}".format(unix_socket))
+
+            localsocket = LocalSocketHttpAuthenticated(unix_socket)
+            client = Client(connection_url, transport=localsocket)
+        else:
+            client = Client(connection_url, username=username, password=password, timeout=10)
+
+        return client
+
+    except Exception as e:
+        raise e
 
 
-def call_sap_control(hostname, port, username, password, function, parameters, sysnr=None, use_local=False):
-    con = connection("sapcontrol", hostname, port, username, password, sysnr=sysnr, use_local=use_local)
-    return call_function(con, function, parameters)
+def call_sap_control(hostname, port, username, password, function, parameters, sysnr=None, is_socket=False):
+    client = connection(
+        "sapcontrol", hostname, port, username, password, sysnr=sysnr, is_socket=is_socket)
+    return call_function(client, function, parameters)
 
 
-def call_sap_hostctrl(hostname, port, username, password, function, parameters, use_local=False):
-    con = connection("SAPHostControl/", hostname, port, username, password, sysnr=None, use_local=use_local)
-    return call_function(con, function, parameters)
+def call_sap_hostctrl(hostname, port, username, password, function, parameters, is_socket=False):
+    client = connection(
+        "SAPHostControl/", hostname, port, username, password, sysnr=None, is_socket=is_socket)
+    return call_function(client, function, parameters)
 
 
 def call_function(client, function, parameters=None):

--- a/plugins/modules/sap_control_exec.py
+++ b/plugins/modules/sap_control_exec.py
@@ -132,8 +132,9 @@ options:
     parameter:
         description:
             - The parameter to pass to the function.
+            - Specific functions require complex parameters to be defined. See example for InstanceStart.
         required: false
-        type: str
+        type: raw
     force:
         description:
             - Forces the execution of the function C(Stop).
@@ -181,6 +182,15 @@ EXAMPLES = r"""
     function: GetProcessList
   become: true
   become_user: "{{ sap_sid | lower }}adm"
+
+- name: InstanceStart with complex parameter
+  community.sap_libs.sap_control_exec:
+    sysnr: "00"
+    function: InstanceStart
+  become: true
+  parameter:
+    host: "s4hana"
+    nr: "00"
 """
 
 RETURN = r'''
@@ -234,6 +244,8 @@ from ..module_utils.sapstartsrv_client import (
     SUDS_LIBRARY_IMPORT_ERROR,
     call_sap_control as connection,
     recursive_dict,
+    is_read_only_function,
+    requires_force,
 )
 
 
@@ -262,7 +274,7 @@ def main():
             password=dict(type='str', no_log=True, required=False),
             hostname=dict(type='str', default="localhost"),
             function=dict(type='str', required=True, choices=choices()),
-            parameter=dict(type='str', required=False),
+            parameter=dict(type='raw', required=False),  # raw will allow dict or string.
             force=dict(type='bool', default=False),
         ),
         # Remove strict requirements to allow local mode
@@ -270,7 +282,7 @@ def main():
         mutually_exclusive=[('sysnr', 'port')],
         supports_check_mode=False,
     )
-    result = dict(changed=False, msg='', out={}, error='')
+    result = dict(changed=False, msg='', out=[], error='')  # Default out to list for consistent return type.
     params = module.params
 
     sysnr = params['sysnr']
@@ -294,9 +306,8 @@ def main():
     if sysnr is not None and port is not None:
         module.fail_json(msg="'sysnr' and 'port' are mutually exclusive")
 
-    if function == "Stop":
-        if force is False:
-            module.fail_json(msg="Stop function requires force: True")
+    if requires_force(function) and force is False:
+        module.fail_json(msg="Function '{0}' requires force: True".format(function))
 
     if function == "StartSystem":
         parameter = dict(waittimeout=0)
@@ -304,44 +315,64 @@ def main():
         parameter = dict(waittimeout=0, softtimeout=0)
 
     # Determine if we should use local Unix socket connection
-    # Use local if hostname is localhost and no username/password provided
-    use_local = (hostname == "localhost" and
+    # Use local socket connection if hostname is localhost and no username/password provided
+    # True: Socket connection, False: SOAP connection
+    is_socket = (hostname == "localhost" and
                  username is None and
                  password is None and
                  sysnr is not None)
 
     if port is None:
         try:
-            if use_local:
-                # Try local connection first
-                result_conn = connection(hostname, None, username, password, function, parameter, sysnr=sysnr, use_local=True)
+            if is_socket:
+                result['connection_type'] = 'socket'
+                result['connection_url'] = "http://localhost/sapcontrol?wsdl"
+
+                result_conn = connection(hostname, None, username, password, function, parameter, sysnr=sysnr, is_socket=True)
             else:
-                # Try HTTP ports
+                result['connection_type'] = 'soap'
+
+                # Try HTTPS and HTTP ports
                 try:
+                    result['connection_url'] = 'http://{0}:5{1}14/sapcontrol?wsdl'.format(hostname, str(sysnr).zfill(2))
                     result_conn = connection(hostname, "5{0}14".format((sysnr).zfill(2)), username, password, function, parameter, sysnr)
                 except Exception:
+                    result['connection_url'] = 'http://{0}:5{1}13/sapcontrol?wsdl'.format(hostname, str(sysnr).zfill(2))
                     result_conn = connection(hostname, "5{0}13".format((sysnr).zfill(2)), username, password, function, parameter, sysnr)
         except Exception as err:
-            result['error'] = str(err)
+            if "already started" in str(err).lower():
+                already_started_msg = "Function {0} returned that Instance is already started.".format(function)
+                result_conn = ({"status": "already_started", "msg": already_started_msg})
+            else:
+                result['error'] = str(err)
     else:
+        result['connection_type'] = 'soap'
+        result['connection_url'] = 'http://{0}:{1}/sapcontrol?wsdl'.format(hostname, port)
         try:
-            result_conn = connection(hostname, port, username, password, function, parameter, sysnr, use_local=False)
+            result_conn = connection(hostname, port, username, password, function, parameter, sysnr, is_socket=False)
         except Exception as err:
-            result['error'] = str(err)
+            if "already started" in str(err).lower():
+                already_started_msg = "Function {0} returned that Instance is already started.".format(function)
+                result_conn = ({"status": "already_started", "msg": already_started_msg})
+            else:
+                result['error'] = str(err)
 
     if result['error'] != '':
-        connection_type = "Unix socket" if use_local else "SOAP API"
-        result['msg'] = 'Something went wrong connecting to the {0}.'.format(connection_type)
+        result['msg'] = 'Function execution has failed. See error for more details.'
         module.fail_json(**result)
 
-    if result_conn is not None:
-        returned_data = recursive_dict(result_conn)
-    else:
-        returned_data = result_conn
+    conn_result = result_conn
 
-    result['changed'] = True
-    result['msg'] = "Succesful execution of: " + function
-    result['out'] = [returned_data]
+    # Ensure that we run recursive_dict only on dict and leave it for idempotent functions.
+    if isinstance(conn_result, dict) and conn_result.get('status') == 'already_started':
+        result['changed'] = False
+        result['msg'] = conn_result.get('msg')
+        result['out'] = [None]  # Ensure we return same content as Start and Stop functions for consistency
+    else:
+        result['changed'] = not is_read_only_function(function)
+        result['msg'] = "Successful execution of function: " + function
+        returned_data = recursive_dict(conn_result) if conn_result is not None else conn_result
+        result['out'] = [returned_data]
 
     module.exit_json(**result)
 

--- a/plugins/modules/sap_hostctrl_exec.py
+++ b/plugins/modules/sap_hostctrl_exec.py
@@ -261,6 +261,8 @@ from ..module_utils.sapstartsrv_client import (
     SUDS_LIBRARY_IMPORT_ERROR,
     recursive_dict,
     call_sap_hostctrl as connection,
+    is_read_only_function,
+    requires_force,
 )
 
 
@@ -288,7 +290,7 @@ def main():
         ),
         supports_check_mode=False,
     )
-    result = dict(changed=False, msg='', out={}, error='')
+    result = dict(changed=False, msg='', out=[], error='')  # Default out to list for consistent return type.
     params = module.params
 
     port = params['port']
@@ -305,47 +307,52 @@ def main():
             exception=SUDS_LIBRARY_IMPORT_ERROR)
 
     # Validate arguments
-    if function == "StopDatabase" or function == "StopInstance":
-        if force is False:
-            module.fail_json(msg="Stop function requires force: True")
+    if requires_force(function) and force is False:
+        module.fail_json(msg="Function '{0}' requires force: True".format(function))
 
     # Determine if we should use local Unix socket connection
-    # Use local if hostname is localhost and no username/password provided
-    use_local = (hostname == "localhost" and
+    # Use local socket connection if hostname is localhost and no username/password provided
+    # True: Socket connection, False: SOAP connection
+    is_socket = (hostname == "localhost" and
                  username is None and
                  password is None)
 
     if port is None:
         try:
-            if use_local:
-                # Try local connection first
-                result_conn = connection(hostname, None, username, password, function, parameters, use_local=True)
+            if is_socket:
+                result['connection_type'] = 'socket'
+                result['connection_url'] = "http://localhost/SAPHostControl/?wsdl"
+
+                result_conn = connection(hostname, None, username, password, function, parameters, is_socket=True)
             else:
-                # Try HTTP ports
+                result['connection_type'] = 'soap'
+
+                # Try HTTPS and HTTP ports
                 try:
+                    result['connection_url'] = 'http://{0}:1129/SAPHostControl/?wsdl'.format(hostname)
                     result_conn = connection(hostname, "1129", username, password, function, parameters)
                 except Exception:
+                    result['connection_url'] = 'http://{0}:1128/SAPHostControl/?wsdl'.format(hostname)
                     result_conn = connection(hostname, "1128", username, password, function, parameters)
         except Exception as err:
             result['error'] = str(err)
     else:
+        result['connection_type'] = 'soap'
+        result['connection_url'] = 'http://{0}:{1}/SAPHostControl/?wsdl'.format(hostname, port)
         try:
-            result_conn = connection(hostname, port, username, password, function, parameters, use_local=False)
+            result_conn = connection(hostname, port, username, password, function, parameters, is_socket=False)
         except Exception as err:
             result['error'] = str(err)
 
     if result['error'] != '':
-        connection_type = "Unix socket" if use_local else "SOAP API"
-        result['msg'] = 'Something went wrong connecting to the {0}.'.format(connection_type)
+        result['msg'] = 'Function execution has failed. See error for more details.'
         module.fail_json(**result)
 
-    if result_conn is not None:
-        returned_data = recursive_dict(result_conn)
-    else:
-        returned_data = result_conn
+    conn_result = result_conn
+    returned_data = recursive_dict(conn_result) if conn_result is not None else conn_result
 
-    result['changed'] = True
-    result['msg'] = "Succesful execution of: " + function
+    result['changed'] = not is_read_only_function(function)
+    result['msg'] = "Successful execution of function: " + function
     result['out'] = [returned_data]
 
     module.exit_json(**result)

--- a/tests/unit/plugins/modules/test_sap_control_exec.py
+++ b/tests/unit/plugins/modules/test_sap_control_exec.py
@@ -31,13 +31,13 @@ class TestSapcontrolModule(ModuleTestCase):
         return mocker.patch(self.module.call_rfc_method)
 
     def test_without_required_parameters(self):
-        """Failure must occurs when all parameters are missing"""
+        """Fail when required parameters are missing."""
         with self.assertRaises(AnsibleFailJson):
             with set_module_args({}):
                 self.module.main()
 
     def test_error_module_not_found(self):
-        """tests fail module error"""
+        """Fail when SUDS library is not found during import."""
 
         args = {
             "hostname": "192.168.8.15",
@@ -53,7 +53,7 @@ class TestSapcontrolModule(ModuleTestCase):
 
     @patch('ansible_collections.community.sap_libs.plugins.module_utils.sapstartsrv_client.Client')
     def test_error_connection(self, mock_client):
-        """tests fail module exception"""
+        """Fail when there is a connection error."""
 
         args = {
             "hostname": "192.168.8.15",
@@ -65,14 +65,10 @@ class TestSapcontrolModule(ModuleTestCase):
             with set_module_args(args):
                 self.module.main()
         error_msg = result.exception.args[0]['msg']
-        expected_messages = [
-            'Something went wrong connecting to the SOAP API.',
-            'Something went wrong connecting to the Unix socket.'
-        ]
-        self.assertIn(error_msg, expected_messages)
+        self.assertEqual(error_msg, 'Function execution has failed. See error for more details.')
 
     def test_error_port_sysnr(self):
-        """tests fail multi provide parameters"""
+        """Fail when both sysnr and port are provided."""
 
         args = {
             "hostname": "192.168.8.15",
@@ -86,7 +82,7 @@ class TestSapcontrolModule(ModuleTestCase):
         self.assertEqual(result.exception.args[0]['msg'], 'parameters are mutually exclusive: sysnr|port')
 
     def test_error_missing_force(self):
-        """tests fail missing force"""
+        """Fail when force parameter is missing."""
 
         args = {
             "hostname": "192.168.8.15",
@@ -97,10 +93,10 @@ class TestSapcontrolModule(ModuleTestCase):
         with self.assertRaises(AnsibleFailJson) as result:
             with set_module_args(args):
                 self.module.main()
-        self.assertEqual(result.exception.args[0]['msg'], 'Stop function requires force: True')
+        self.assertEqual(result.exception.args[0]['msg'], "Function 'Stop' requires force: True")
 
     def test_success_sysnr(self):
-        """test success with sysnr"""
+        """Test successful connection with sysnr."""
 
         args = {
             "hostname": "192.168.8.15",
@@ -117,7 +113,7 @@ class TestSapcontrolModule(ModuleTestCase):
         self.assertEqual(result.exception.args[0]['out'], [{'item': [{'name': 'hdbdaemon', 'value': '1'}]}])
 
     def test_success_port(self):
-        """test success with port"""
+        """Test successful connection with port."""
 
         args = {
             "hostname": "192.168.8.15",
@@ -134,7 +130,7 @@ class TestSapcontrolModule(ModuleTestCase):
         self.assertEqual(result.exception.args[0]['out'], [{'item': [{'name': 'hdbdaemon', 'value': '1'}]}])
 
     def test_success_string(self):
-        """test success with sysnr"""
+        """Test successful connection with sysnr."""
 
         args = {
             "hostname": "192.168.8.15",
@@ -148,3 +144,48 @@ class TestSapcontrolModule(ModuleTestCase):
                 with set_module_args(args):
                     self.module.main()
         self.assertEqual(result.exception.args[0]['out'], ['1600000'])
+
+    def test_success_already_started(self):
+        """Test successful connection when an instance is already running."""
+        args = {
+            "hostname": "192.168.8.15",
+            "sysnr": "01",
+            "function": "Start"
+        }
+        error_text = "Server raised fault: 'Instance already started'"
+
+        with patch.object(self.module, 'connection') as mock_connection:
+            mock_connection.side_effect = Exception(error_text)
+
+            with self.assertRaises(AnsibleExitJson) as result:
+                with set_module_args(args):
+                    self.module.main()
+
+        res = result.exception.args[0]
+        self.assertFalse(res['changed'])
+        self.assertEqual(res['out'], [None])
+        self.assertIn("already started", res['msg'])
+
+    def test_success_complex_parameter(self):
+        """Test passing a dictionary as a parameter (e.g. InstanceStart)."""
+        args = {
+            "hostname": "192.168.8.15",
+            "sysnr": "01",
+            "function": "InstanceStart",
+            "parameter": {
+                "host": "s4hana",
+                "nr": 0
+            }
+        }
+
+        with patch.object(self.module, 'connection') as mock_connection:
+            mock_connection.return_value = None
+
+            with self.assertRaises(AnsibleExitJson) as result:
+                with set_module_args(args):
+                    self.module.main()
+
+        res = result.exception.args[0]
+        self.assertTrue(res['changed'])
+        self.assertEqual(res['out'], [None])
+        self.assertEqual(res['msg'], "Successful execution of function: InstanceStart")

--- a/tests/unit/plugins/modules/test_sap_hostctrl_exec.py
+++ b/tests/unit/plugins/modules/test_sap_hostctrl_exec.py
@@ -31,13 +31,13 @@ class TestSapcontrolModule(ModuleTestCase):
         return mocker.patch(self.module.call_rfc_method)
 
     def test_without_required_parameters(self):
-        """Failure must occurs when all parameters are missing"""
+        """Fail when required parameters are missing."""
         with self.assertRaises(AnsibleFailJson):
             with set_module_args({}):
                 self.module.main()
 
     def test_error_module_not_found(self):
-        """tests fail module error"""
+        """Fail when SUDS library is not found during import."""
 
         args = {
             "hostname": "192.168.8.15",
@@ -52,7 +52,7 @@ class TestSapcontrolModule(ModuleTestCase):
 
     @patch('ansible_collections.community.sap_libs.plugins.module_utils.sapstartsrv_client.Client')
     def test_error_connection(self, mock_client):
-        """tests fail module exception"""
+        """Fail when there is a connection error."""
 
         args = {
             "hostname": "192.168.8.15",
@@ -63,14 +63,10 @@ class TestSapcontrolModule(ModuleTestCase):
             with set_module_args(args):
                 self.module.main()
         error_msg = result.exception.args[0]['msg']
-        expected_messages = [
-            'Something went wrong connecting to the SOAP API.',
-            'Something went wrong connecting to the Unix socket.'
-        ]
-        self.assertIn(error_msg, expected_messages)
+        self.assertEqual(error_msg, 'Function execution has failed. See error for more details.')
 
     def test_error_missing_force(self):
-        """tests fail missing force"""
+        """Fail when force parameter is missing."""
 
         args = {
             "hostname": "192.168.8.15",
@@ -80,10 +76,10 @@ class TestSapcontrolModule(ModuleTestCase):
         with self.assertRaises(AnsibleFailJson) as result:
             with set_module_args(args):
                 self.module.main()
-        self.assertEqual(result.exception.args[0]['msg'], 'Stop function requires force: True')
+        self.assertEqual(result.exception.args[0]['msg'], "Function 'StopInstance' requires force: True")
 
     def test_success_list_instances(self):
-        """test success with ListInstances"""
+        """Test successful execution of ListInstances."""
 
         args = {
             "hostname": "192.168.8.15",
@@ -103,7 +99,7 @@ class TestSapcontrolModule(ModuleTestCase):
         self.assertEqual(result.exception.args[0]['out'], [ret_dict])
 
     def test_success_port(self):
-        """test success with port"""
+        """Test successful execution with port."""
 
         args = {
             "hostname": "192.168.8.15",
@@ -124,7 +120,7 @@ class TestSapcontrolModule(ModuleTestCase):
         self.assertEqual(result.exception.args[0]['out'], [ret_dict])
 
     def test_success_local(self):
-        """test success with local port"""
+        """Test successful execution with local port."""
 
         args = {
             "function": "ListInstances"
@@ -143,7 +139,7 @@ class TestSapcontrolModule(ModuleTestCase):
         self.assertEqual(result.exception.args[0]['out'], [ret_dict])
 
     def test_success_parameters(self):
-        """test success with parameters"""
+        """Test successful execution with parameters."""
 
         args = {
             "hostname": "192.168.8.15",


### PR DESCRIPTION
## Changes
Following issues were found during recent pull requests and fixed in this PR:
- Add validation of hostname to avoid soap failures
- Add handling of `changed_when` to trigger only for functions were cannot be sure that changes occured. List of read only functions is defined in new constant `READ_ONLY_FUNCTION_PREFIXES`.
- Add handling for `force` functions, because previously it was covering only `Stop` function which was not enough. New  constants for filtering `FORCE_REQUIRED_PREFIXES` and `FORCE_REQUIRED_EXACT`.
- New output parameters to make debugging simpler
  - `connection_type`
  - `connection_url`
- Idempotent handling for `'Server raised fault: ''Instance already started'''` when starting instances.
- Improve clarity of `use_local` by changing it to `is_socket_transport`

## Tests
Tested on SLES_SAP 16.0 running BW4HANA system.

## Output Examples
Following output examples show changes to handling
```console
    __start_instance_soap_sysnr:
        changed: false
        connection_type: socket
        connection_url: http://localhost/sapcontrol?wsdl
        error: ''
        failed: false
        msg: Function InstanceStart returned that Instance is already started.
        out:
        - null
 ```

```console
    __getversioninfo_socket_port:
        changed: false
        connection_type: soap
        connection_url: http://localhost:50013/sapcontrol?wsdl
        error: ''
        failed: false
        msg: 'Successful execution of function: GetVersionInfo'
        out:
        -   item:
            -   Filename: /usr/sap/B01/ASCS00/exe/sapstartsrv
                Time: 2023 09 13 19:10:58
                VersionInfo: 793, patch 51, commit 375ae433dffb023985041c1d7b4687b1bde8d211,
                    RKS compatibility level 0, optU (Sep 13 2023, 20:37:54), linuxx86_64
```

```console
fatal: [b01hana]: FAILED! =>
    changed: false
    connection_type: soap
    connection_url: http://b01hanax:50013/sapcontrol?wsdl
    error: <urlopen error [Errno -2] Name or service not known>
    msg: Function execution has failed. See error for more details.
    out: []
```

```console
    __startinstance_socket:
        changed: true
        connection_type: socket
        connection_url: http://localhost/SAPHostControl/?wsdl
        error: ''
        failed: false
        msg: 'Successful execution of function: StartInstance'
        out:
        -   mOperationID: 8E3906D0F8DD1FD187C01EE68C59C000
            mOperationResults: ''
```