### PR TITLE
collection: Update all license headers

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -20,13 +20,22 @@ For specific role maintainers, see the `README.md` file in the corresponding rol
 | Name | Commits | Lines Changed | Last Commit |
 | ---- | ------- | ------------- | ----------- |
 | [Rainer Leber](https://github.com/rainerleber) | 23 | 11921 | 2025-09-22 |
-| ydouvry | 8 | 892 | 2025-12-09 |
+| [Marcel Mamula](https://github.com/marcelmamula) | 19 | 2799 | 2026-03-13 |
+| ydouvry | 9 | 966 | 2026-02-27 |
 | Nicolas Bettembourg | 7 | 265 | 2025-10-27 |
-| [Marcel Mamula](https://github.com/marcelmamula) | 4 | 1404 | 2025-10-16 |
+| mmalagowski | 2 | 12 | 2026-02-27 |
+| MelvinM-coder | 1 | 477 | 2026-02-26 |
 | stm85 | 1 | 4 | 2024-04-29 |
 | [Sean Freeman](https://github.com/sean-freeman) | 1 | 3 | 2022-11-11 |
 
 ## Contributions by Module
+
+### Module: sap_company.py
+
+| Name | Commits | Lines Changed | Last Commit |
+| ---- | ------- | ------------- | ----------- |
+| [Rainer Leber](https://github.com/rainerleber) | 3 | 337 | 2022-12-05 |
+| [Marcel Mamula](https://github.com/marcelmamula) | 1 | 10 | 2026-03-13 |
 
 ### Module: sap_control_exec.py
 
@@ -34,23 +43,48 @@ For specific role maintainers, see the `README.md` file in the corresponding rol
 | ---- | ------- | ------------- | ----------- |
 | Nicolas Bettembourg | 4 | 221 | 2025-10-27 |
 | [Rainer Leber](https://github.com/rainerleber) | 4 | 555 | 2025-09-22 |
+| [Marcel Mamula](https://github.com/marcelmamula) | 2 | 89 | 2026-03-13 |
+| mmalagowski | 1 | 2 | 2026-02-27 |
+| ydouvry | 1 | 20 | 2026-02-27 |
+| MelvinM-coder | 1 | 158 | 2026-02-26 |
+
+### Module: sap_hdbsql.py
+
+| Name | Commits | Lines Changed | Last Commit |
+| ---- | ------- | ------------- | ----------- |
+| [Marcel Mamula](https://github.com/marcelmamula) | 4 | 176 | 2026-03-13 |
+| Stollek | 1 | 22 | 2026-03-11 |
+| stm85 | 1 | 2 | 2024-04-29 |
+| [Rainer Leber](https://github.com/rainerleber) | 1 | 246 | 2022-09-09 |
+
+### Module: sap_hostctrl_exec.py
+
+| Name | Commits | Lines Changed | Last Commit |
+| ---- | ------- | ------------- | ----------- |
+| ydouvry | 10 | 528 | 2026-02-27 |
+| [Marcel Mamula](https://github.com/marcelmamula) | 2 | 56 | 2026-03-13 |
+| mmalagowski | 1 | 2 | 2026-02-27 |
+| MelvinM-coder | 1 | 149 | 2026-02-26 |
 
 ### Module: sap_pyrfc.py
 
 | Name | Commits | Lines Changed | Last Commit |
 | ---- | ------- | ------------- | ----------- |
 | [Rainer Leber](https://github.com/rainerleber) | 4 | 191 | 2023-03-08 |
+| [Marcel Mamula](https://github.com/marcelmamula) | 1 | 11 | 2026-03-13 |
 
 ### Module: sap_snote.py
 
 | Name | Commits | Lines Changed | Last Commit |
 | ---- | ------- | ------------- | ----------- |
 | [Rainer Leber](https://github.com/rainerleber) | 3 | 269 | 2022-12-05 |
+| [Marcel Mamula](https://github.com/marcelmamula) | 1 | 10 | 2026-03-13 |
 
 ### Module: sap_system_facts.py
 
 | Name | Commits | Lines Changed | Last Commit |
 | ---- | ------- | ------------- | ----------- |
+| [Marcel Mamula](https://github.com/marcelmamula) | 5 | 189 | 2026-03-13 |
 | [Rainer Leber](https://github.com/rainerleber) | 2 | 215 | 2022-09-09 |
 
 ### Module: sap_task_list_execute.py
@@ -58,36 +92,128 @@ For specific role maintainers, see the `README.md` file in the corresponding rol
 | Name | Commits | Lines Changed | Last Commit |
 | ---- | ------- | ------------- | ----------- |
 | [Rainer Leber](https://github.com/rainerleber) | 3 | 352 | 2022-12-05 |
-
-### Module: sap_hostctrl_exec.py
-
-| Name | Commits | Lines Changed | Last Commit |
-| ---- | ------- | ------------- | ----------- |
-| ydouvry | 8 | 506 | 2025-12-09 |
-
-### Module: sapcar_extract.py
-
-| Name | Commits | Lines Changed | Last Commit |
-| ---- | ------- | ------------- | ----------- |
-| [Rainer Leber](https://github.com/rainerleber) | 2 | 230 | 2022-09-09 |
-
-### Module: sap_hdbsql.py
-
-| Name | Commits | Lines Changed | Last Commit |
-| ---- | ------- | ------------- | ----------- |
-| [Marcel Mamula](https://github.com/marcelmamula) | 1 | 2 | 2025-09-25 |
-| stm85 | 1 | 2 | 2024-04-29 |
-| [Rainer Leber](https://github.com/rainerleber) | 1 | 246 | 2022-09-09 |
+| [Marcel Mamula](https://github.com/marcelmamula) | 1 | 10 | 2026-03-13 |
 
 ### Module: sap_user.py
 
 | Name | Commits | Lines Changed | Last Commit |
 | ---- | ------- | ------------- | ----------- |
 | [Rainer Leber](https://github.com/rainerleber) | 3 | 510 | 2022-12-05 |
+| [Marcel Mamula](https://github.com/marcelmamula) | 1 | 10 | 2026-03-13 |
 
-### Module: sap_company.py
+### Module: sapcar_extract.py
 
 | Name | Commits | Lines Changed | Last Commit |
 | ---- | ------- | ------------- | ----------- |
-| [Rainer Leber](https://github.com/rainerleber) | 3 | 337 | 2022-12-05 |
+| [Marcel Mamula](https://github.com/marcelmamula) | 4 | 103 | 2026-03-13 |
+| [Rainer Leber](https://github.com/rainerleber) | 2 | 230 | 2022-09-09 |
+
+## Contributions by Module Utilities
+
+### Utility: pyrfc_handler.py
+
+| Name | Commits | Lines Changed | Last Commit |
+| ---- | ------- | ------------- | ----------- |
+| [Rainer Leber](https://github.com/rainerleber) | 2 | 50 | 2022-09-09 |
+| [Marcel Mamula](https://github.com/marcelmamula) | 1 | 11 | 2026-03-13 |
+
+### Utility: sapstartsrv_client.py
+
+| Name | Commits | Lines Changed | Last Commit |
+| ---- | ------- | ------------- | ----------- |
+| [Marcel Mamula](https://github.com/marcelmamula) | 2 | 95 | 2026-03-13 |
+| mmalagowski | 1 | 164 | 2026-02-27 |
+
+### Utility: swpm2_parameters_inifile_generate.py
+
+| Name | Commits | Lines Changed | Last Commit |
+| ---- | ------- | ------------- | ----------- |
+| [Marcel Mamula](https://github.com/marcelmamula) | 1 | 10 | 2026-03-13 |
+| [Sean Freeman](https://github.com/sean-freeman) | 1 | 3 | 2022-11-11 |
+| [Rainer Leber](https://github.com/rainerleber) | 1 | 268 | 2022-09-09 |
+
+## Contributions by Module Unit Tests
+
+### Test: test_sap_company.py
+
+| Name | Commits | Lines Changed | Last Commit |
+| ---- | ------- | ------------- | ----------- |
+| [Marcel Mamula](https://github.com/marcelmamula) | 2 | 53 | 2026-03-13 |
+| [Rainer Leber](https://github.com/rainerleber) | 1 | 136 | 2022-09-09 |
+
+### Test: test_sap_control_exec.py
+
+| Name | Commits | Lines Changed | Last Commit |
+| ---- | ------- | ------------- | ----------- |
+| [Marcel Mamula](https://github.com/marcelmamula) | 3 | 143 | 2026-03-13 |
+| Nicolas Bettembourg | 2 | 41 | 2025-10-27 |
+| mmalagowski | 1 | 2 | 2026-02-27 |
+| MelvinM-coder | 1 | 5 | 2026-02-26 |
+| [Rainer Leber](https://github.com/rainerleber) | 1 | 129 | 2022-09-09 |
+
+### Test: test_sap_hdbsql.py
+
+| Name | Commits | Lines Changed | Last Commit |
+| ---- | ------- | ------------- | ----------- |
+| [Marcel Mamula](https://github.com/marcelmamula) | 4 | 140 | 2026-03-13 |
+| Stollek | 1 | 20 | 2026-03-11 |
+| [Rainer Leber](https://github.com/rainerleber) | 1 | 102 | 2022-09-09 |
+
+### Test: test_sap_hostctrl_exec.py
+
+| Name | Commits | Lines Changed | Last Commit |
+| ---- | ------- | ------------- | ----------- |
+| ydouvry | 3 | 364 | 2025-12-08 |
+| [Marcel Mamula](https://github.com/marcelmamula) | 2 | 43 | 2026-03-13 |
+| mmalagowski | 1 | 2 | 2026-02-27 |
+| MelvinM-coder | 1 | 5 | 2026-02-26 |
+
+### Test: test_sap_pyrfc.py
+
+| Name | Commits | Lines Changed | Last Commit |
+| ---- | ------- | ------------- | ----------- |
+| [Marcel Mamula](https://github.com/marcelmamula) | 2 | 29 | 2026-03-13 |
+| [Rainer Leber](https://github.com/rainerleber) | 1 | 76 | 2022-07-18 |
+
+### Test: test_sap_snote.py
+
+| Name | Commits | Lines Changed | Last Commit |
+| ---- | ------- | ------------- | ----------- |
+| [Marcel Mamula](https://github.com/marcelmamula) | 2 | 88 | 2026-03-13 |
+| [Rainer Leber](https://github.com/rainerleber) | 1 | 181 | 2022-09-09 |
+
+### Test: test_sap_system_facts.py
+
+| Name | Commits | Lines Changed | Last Commit |
+| ---- | ------- | ------------- | ----------- |
+| [Marcel Mamula](https://github.com/marcelmamula) | 5 | 76 | 2026-03-13 |
+| [Rainer Leber](https://github.com/rainerleber) | 2 | 109 | 2023-03-08 |
+
+### Test: test_sap_task_list_execute.py
+
+| Name | Commits | Lines Changed | Last Commit |
+| ---- | ------- | ------------- | ----------- |
+| [Marcel Mamula](https://github.com/marcelmamula) | 2 | 46 | 2026-03-13 |
+| [Rainer Leber](https://github.com/rainerleber) | 1 | 89 | 2022-09-09 |
+
+### Test: test_sap_user.py
+
+| Name | Commits | Lines Changed | Last Commit |
+| ---- | ------- | ------------- | ----------- |
+| [Marcel Mamula](https://github.com/marcelmamula) | 2 | 67 | 2026-03-13 |
+| [Rainer Leber](https://github.com/rainerleber) | 1 | 189 | 2022-09-09 |
+
+### Test: test_sapcar_extract.py
+
+| Name | Commits | Lines Changed | Last Commit |
+| ---- | ------- | ------------- | ----------- |
+| [Marcel Mamula](https://github.com/marcelmamula) | 3 | 58 | 2026-03-13 |
+| [Rainer Leber](https://github.com/rainerleber) | 1 | 53 | 2022-09-09 |
+
+### Test: utils.py
+
+| Name | Commits | Lines Changed | Last Commit |
+| ---- | ------- | ------------- | ----------- |
+| [Marcel Mamula](https://github.com/marcelmamula) | 2 | 43 | 2026-03-13 |
+| [Rainer Leber](https://github.com/rainerleber) | 1 | 52 | 2022-04-24 |
 

--- a/plugins/module_utils/pyrfc_handler.py
+++ b/plugins/module_utils/pyrfc_handler.py
@@ -1,16 +1,21 @@
-# -*- coding: utf-8 -*-
+#!/usr/bin/env python
 
-# Copyright: (c) 2022, Sean Freeman ,
-#                      Rainer Leber <rainerleber@gmail.com> <rainer.leber@sva.de>
+# Copyright (c) 2022-2026 The Project Contributors.
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
+#
 #     http://www.apache.org/licenses/LICENSE-2.0
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+#
+# For a detailed list of copyright holders and contribution history,
+# please refer to the CONTRIBUTORS.md file in the project root.
 
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type

--- a/plugins/module_utils/sapstartsrv_client.py
+++ b/plugins/module_utils/sapstartsrv_client.py
@@ -1,18 +1,21 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
 
-# Copyright: (c) 2026, Sean Freeman ,
-# Rainer Leber <rainerleber@gmail.com> <rainer.leber@sva.de>
-# Melvin Malagowski <mmalagowski@oxya.com>
+# Copyright (c) 2022-2026 The Project Contributors.
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
+#
 #     http://www.apache.org/licenses/LICENSE-2.0
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+#
+# For a detailed list of copyright holders and contribution history,
+# please refer to the CONTRIBUTORS.md file in the project root.
 
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type

--- a/plugins/module_utils/swpm2_parameters_inifile_generate.py
+++ b/plugins/module_utils/swpm2_parameters_inifile_generate.py
@@ -1,17 +1,21 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
 
-# Copyright: (c) 2022, Sean Freeman ,
-#                      Rainer Leber <rainerleber@gmail.com> <rainer.leber@sva.de>
+# Copyright (c) 2022-2026 The Project Contributors.
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
+#
 #     http://www.apache.org/licenses/LICENSE-2.0
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+#
+# For a detailed list of copyright holders and contribution history,
+# please refer to the CONTRIBUTORS.md file in the project root.
 
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type

--- a/plugins/modules/sap_company.py
+++ b/plugins/modules/sap_company.py
@@ -1,16 +1,22 @@
 #!/usr/bin/python
-# -*- coding: utf-8 -*-
 
-# Copyright: (c) 2021, Rainer Leber <rainerleber@gmail.com> <rainer.leber@sva.de>
+# Copyright (c) 2022-2026 The Project Contributors.
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
+#
 #     http://www.apache.org/licenses/LICENSE-2.0
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+#
+# For a detailed list of copyright holders and contribution history,
+# please refer to the CONTRIBUTORS.md file in the project root.
+
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 

--- a/plugins/modules/sap_control_exec.py
+++ b/plugins/modules/sap_control_exec.py
@@ -1,16 +1,22 @@
 #!/usr/bin/python
 
-# Copyright: (c) 2022, Rainer Leber rainerleber@gmail.com, rainer.leber@sva.de,
-#                      Robert Kraemer @rkpobe, robert.kraemer@sva.de
+# Copyright (c) 2022-2026 The Project Contributors.
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
+#
 #     http://www.apache.org/licenses/LICENSE-2.0
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+#
+# For a detailed list of copyright holders and contribution history,
+# please refer to the CONTRIBUTORS.md file in the project root.
+
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 

--- a/plugins/modules/sap_hdbsql.py
+++ b/plugins/modules/sap_hdbsql.py
@@ -1,16 +1,22 @@
 #!/usr/bin/python
-# -*- coding: utf-8 -*-
 
-# Copyright: (c) 2021, Rainer Leber <rainerleber@gmail.com>
+# Copyright (c) 2022-2026 The Project Contributors.
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
+#
 #     http://www.apache.org/licenses/LICENSE-2.0
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+#
+# For a detailed list of copyright holders and contribution history,
+# please refer to the CONTRIBUTORS.md file in the project root.
+
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 

--- a/plugins/modules/sap_hostctrl_exec.py
+++ b/plugins/modules/sap_hostctrl_exec.py
@@ -1,17 +1,22 @@
 #!/usr/bin/python
 
-# Copyright: (c) 2022, Rainer Leber rainerleber@gmail.com, rainer.leber@sva.de,
-#                      Robert Kraemer @rkpobe, robert.kraemer@sva.de,
-#                      Yannick Douvry, ydouvry@oxya.com
+# Copyright (c) 2022-2026 The Project Contributors.
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
+#
 #     http://www.apache.org/licenses/LICENSE-2.0
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+#
+# For a detailed list of copyright holders and contribution history,
+# please refer to the CONTRIBUTORS.md file in the project root.
+
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 

--- a/plugins/modules/sap_pyrfc.py
+++ b/plugins/modules/sap_pyrfc.py
@@ -1,17 +1,22 @@
 #!/usr/bin/python
-# -*- coding: utf-8 -*-
 
-# Copyright: (c) 2022, Sean Freeman ,
-#                      Rainer Leber <rainerleber@gmail.com> <rainer.leber@sva.de>
+# Copyright (c) 2022-2026 The Project Contributors.
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
+#
 #     http://www.apache.org/licenses/LICENSE-2.0
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+#
+# For a detailed list of copyright holders and contribution history,
+# please refer to the CONTRIBUTORS.md file in the project root.
+
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 

--- a/plugins/modules/sap_snote.py
+++ b/plugins/modules/sap_snote.py
@@ -1,16 +1,22 @@
 #!/usr/bin/python
-# -*- coding: utf-8 -*-
 
-# Copyright: (c) 2021, Rainer Leber <rainerleber@gmail.com> <rainer.leber@sva.de>
+# Copyright (c) 2022-2026 The Project Contributors.
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
+#
 #     http://www.apache.org/licenses/LICENSE-2.0
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+#
+# For a detailed list of copyright holders and contribution history,
+# please refer to the CONTRIBUTORS.md file in the project root.
+
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 

--- a/plugins/modules/sap_system_facts.py
+++ b/plugins/modules/sap_system_facts.py
@@ -1,15 +1,22 @@
 #!/usr/bin/python
 
-# Copyright: (c) 2022, Rainer Leber rainerleber@gmail.com>
+# Copyright (c) 2022-2026 The Project Contributors.
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
+#
 #     http://www.apache.org/licenses/LICENSE-2.0
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+#
+# For a detailed list of copyright holders and contribution history,
+# please refer to the CONTRIBUTORS.md file in the project root.
+
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 

--- a/plugins/modules/sap_task_list_execute.py
+++ b/plugins/modules/sap_task_list_execute.py
@@ -1,16 +1,22 @@
 #!/usr/bin/python
-# -*- coding: utf-8 -*-
 
-# Copyright: (c) 2021, Rainer Leber <rainerleber@gmail.com>
+# Copyright (c) 2022-2026 The Project Contributors.
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
+#
 #     http://www.apache.org/licenses/LICENSE-2.0
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+#
+# For a detailed list of copyright holders and contribution history,
+# please refer to the CONTRIBUTORS.md file in the project root.
+
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 

--- a/plugins/modules/sap_user.py
+++ b/plugins/modules/sap_user.py
@@ -1,16 +1,22 @@
 #!/usr/bin/python
-# -*- coding: utf-8 -*-
 
-# Copyright: (c) 2021, Rainer Leber <rainerleber@gmail.com> <rainer.leber@sva.de>
+# Copyright (c) 2022-2026 The Project Contributors.
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
+#
 #     http://www.apache.org/licenses/LICENSE-2.0
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+#
+# For a detailed list of copyright holders and contribution history,
+# please refer to the CONTRIBUTORS.md file in the project root.
+
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 

--- a/plugins/modules/sapcar_extract.py
+++ b/plugins/modules/sapcar_extract.py
@@ -1,16 +1,22 @@
 #!/usr/bin/python
-# -*- coding: utf-8 -*-
 
-# Copyright: (c) 2021, Rainer Leber <rainerleber@gmail.com>
+# Copyright (c) 2022-2026 The Project Contributors.
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
+#
 #     http://www.apache.org/licenses/LICENSE-2.0
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+#
+# For a detailed list of copyright holders and contribution history,
+# please refer to the CONTRIBUTORS.md file in the project root.
+
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 

--- a/tests/unit/plugins/modules/test_sap_company.py
+++ b/tests/unit/plugins/modules/test_sap_company.py
@@ -1,4 +1,21 @@
-# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+#!/usr/bin/env python
+
+# Copyright (c) 2022-2026 The Project Contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# For a detailed list of copyright holders and contribution history,
+# please refer to the CONTRIBUTORS.md file in the project root.
 
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type

--- a/tests/unit/plugins/modules/test_sap_control_exec.py
+++ b/tests/unit/plugins/modules/test_sap_control_exec.py
@@ -1,4 +1,21 @@
-# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+#!/usr/bin/env python
+
+# Copyright (c) 2022-2026 The Project Contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# For a detailed list of copyright holders and contribution history,
+# please refer to the CONTRIBUTORS.md file in the project root.
 
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type

--- a/tests/unit/plugins/modules/test_sap_hdbsql.py
+++ b/tests/unit/plugins/modules/test_sap_hdbsql.py
@@ -1,7 +1,21 @@
-# -*- coding: utf-8 -*-
+#!/usr/bin/env python
 
-# Copyright: (c) 2021, Rainer Leber (@rainerleber) <rainerleber@gmail.com>
-# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+# Copyright (c) 2022-2026 The Project Contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# For a detailed list of copyright holders and contribution history,
+# please refer to the CONTRIBUTORS.md file in the project root.
 
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type

--- a/tests/unit/plugins/modules/test_sap_hostctrl_exec.py
+++ b/tests/unit/plugins/modules/test_sap_hostctrl_exec.py
@@ -1,4 +1,21 @@
-# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+#!/usr/bin/env python
+
+# Copyright (c) 2022-2026 The Project Contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# For a detailed list of copyright holders and contribution history,
+# please refer to the CONTRIBUTORS.md file in the project root.
 
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type

--- a/tests/unit/plugins/modules/test_sap_pyrfc.py
+++ b/tests/unit/plugins/modules/test_sap_pyrfc.py
@@ -1,12 +1,21 @@
+#!/usr/bin/env python
+
+# Copyright (c) 2022-2026 The Project Contributors.
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
+#
 #     http://www.apache.org/licenses/LICENSE-2.0
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+#
+# For a detailed list of copyright holders and contribution history,
+# please refer to the CONTRIBUTORS.md file in the project root.
 
 from __future__ import (absolute_import, division, print_function)
 

--- a/tests/unit/plugins/modules/test_sap_snote.py
+++ b/tests/unit/plugins/modules/test_sap_snote.py
@@ -1,4 +1,21 @@
-# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+#!/usr/bin/env python
+
+# Copyright (c) 2022-2026 The Project Contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# For a detailed list of copyright holders and contribution history,
+# please refer to the CONTRIBUTORS.md file in the project root.
 
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type

--- a/tests/unit/plugins/modules/test_sap_system_facts.py
+++ b/tests/unit/plugins/modules/test_sap_system_facts.py
@@ -1,7 +1,21 @@
-# -*- coding: utf-8 -*-
+#!/usr/bin/env python
 
-# Copyright: (c) 2021, Rainer Leber (@rainerleber) <rainerleber@gmail.com>
-# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+# Copyright (c) 2022-2026 The Project Contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# For a detailed list of copyright holders and contribution history,
+# please refer to the CONTRIBUTORS.md file in the project root.
 
 from __future__ import absolute_import, division, print_function
 

--- a/tests/unit/plugins/modules/test_sap_task_list_execute.py
+++ b/tests/unit/plugins/modules/test_sap_task_list_execute.py
@@ -1,4 +1,21 @@
-# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+#!/usr/bin/env python
+
+# Copyright (c) 2022-2026 The Project Contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# For a detailed list of copyright holders and contribution history,
+# please refer to the CONTRIBUTORS.md file in the project root.
 
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type

--- a/tests/unit/plugins/modules/test_sap_user.py
+++ b/tests/unit/plugins/modules/test_sap_user.py
@@ -1,4 +1,21 @@
-# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+#!/usr/bin/env python
+
+# Copyright (c) 2022-2026 The Project Contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# For a detailed list of copyright holders and contribution history,
+# please refer to the CONTRIBUTORS.md file in the project root.
 
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type

--- a/tests/unit/plugins/modules/test_sapcar_extract.py
+++ b/tests/unit/plugins/modules/test_sapcar_extract.py
@@ -1,7 +1,21 @@
-# -*- coding: utf-8 -*-
+#!/usr/bin/env python
 
-# Copyright: (c) 2021, Rainer Leber (@rainerleber) <rainerleber@gmail.com>
-# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+# Copyright (c) 2022-2026 The Project Contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# For a detailed list of copyright holders and contribution history,
+# please refer to the CONTRIBUTORS.md file in the project root.
 
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type

--- a/tests/unit/plugins/modules/utils.py
+++ b/tests/unit/plugins/modules/utils.py
@@ -1,4 +1,21 @@
-# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+#!/usr/bin/env python
+
+# Copyright (c) 2022-2026 The Project Contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# For a detailed list of copyright holders and contribution history,
+# please refer to the CONTRIBUTORS.md file in the project root.
 
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type


### PR DESCRIPTION
## Changes
Modules and Unit tests had inconsistent license headers and this PR addresses that:

- All license headers are identical and point towards `CONTRIBUTORS.md` file which is programmatically maintained and more accurate than names in license headers.
  - **Original authors are still retained in module doc section.**
- Remove invalid GPL-3 headers in Unit Tests that date back to start of project and were left there by mistake.
- Update  `CONTRIBUTORS.md` with new sections with Module Utilities and Module Unit Tests to provide better granularity for contributors.